### PR TITLE
DZ60 QMK Underglow implementation 

### DIFF
--- a/app/components/keyboard.js
+++ b/app/components/keyboard.js
@@ -40,6 +40,7 @@ type Props = {
   clearSelectedKey: (arg: any) => void,
   updateSelectedKey: (val: number) => void,
   updateBrightness: (val: number) => void,
+  updateUnderglowBrightness: (val: number) => void,
   updateLayer: (val: number) => void,
   prevKeyboard: () => Promise<void>,
   nextKeyboard: () => Promise<void>
@@ -151,6 +152,7 @@ export class Keyboard extends Component<Props> {
     const {
       activeLayer,
       lightingData,
+      underglowData,
       selectedKey,
       selectedKeyboard,
       selectedTitle,
@@ -160,6 +162,7 @@ export class Keyboard extends Component<Props> {
       updateLayer,
       loaded,
       updateBrightness,
+      updateUnderglowBrightness,
       matrixKeycodes = []
     } = this.props;
     const device = this.getDevice();
@@ -168,7 +171,7 @@ export class Keyboard extends Component<Props> {
       const {res: selectedLayout, colorMap} = getLayoutFromDevice(device);
       const matrixLayout = MatrixLayout[keyboard.name].layout;
       const showLayer = selectedTitle === Title.KEYS;
-      const showBrightness = selectedTitle === Title.LIGHTING;
+      const showBrightness = selectedTitle === Title.LIGHTING || selectedTitle === Title.UNDERGLOW;
       const useMatrixKeycodes = this.useMatrixKeycodes();
       const clickable = loaded && showLayer;
       let keyCounter = 0;
@@ -223,6 +226,13 @@ export class Keyboard extends Component<Props> {
             <BrightnessControl
               brightness={lightingData.brightness}
               updateBrightness={updateBrightness}
+              showControl={showBrightness}
+            />
+          )}
+          {underglowData && (
+            <BrightnessControl
+              brightness={underglowData.brightness}
+              updateBrightness={updateUnderglowBrightness}
               showControl={showBrightness}
             />
           )}

--- a/app/components/menus/index.js
+++ b/app/components/menus/index.js
@@ -1,3 +1,4 @@
 export {KeycodeMenu} from './keycode-menu';
 export {LightingMenu} from './lighting-menu';
+export {UnderglowMenu} from './underglow-menu';
 export {DebugMenu} from './debug-menu';

--- a/app/components/menus/underglow-menu.js
+++ b/app/components/menus/underglow-menu.js
@@ -1,0 +1,104 @@
+import React, {Component} from 'react';
+import {
+  BrightnessCategory,
+  ColorCategory,
+  PatternCategory
+} from '../underglow-categories';
+import styles from './lighting-menu.css';
+
+export const Category = {
+  Pattern: 'Effects',
+  Color1: 'Primary Color',
+  Color2: 'Secondary Color',
+  Color3: 'Color 3',
+  Color4: 'Color 4',
+  Color5: 'Color 5',
+  Color6: 'Color 6',
+  Brightness: 'Brightness'
+};
+
+export class UnderglowMenu extends Component {
+  constructor(props) {
+    super();
+    this.state = {
+      selectedCategory: Category.Pattern
+    };
+  }
+
+  renderCategories() {
+    const {selectedCategory} = this.state;
+    console.log('selectedCategory', selectedCategory);
+    const menu = [Category.Pattern];
+    console.log('menu', menu);
+    return (
+      <div className={styles.categories}>
+        {menu.map(label => (
+          <div
+            onClick={_ => this.setState({selectedCategory: label})}
+            key={label}
+            className={[
+              label === selectedCategory && styles.selected,
+              styles.category
+            ].join(' ')}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  renderColors(colorsNeeded) {
+    const { underglowData } = this.props;
+    const res = [];
+    for (let i = 1; i <= 1; i++) {
+      res.push((
+        <ColorCategory
+          key={`Color ${i}`}
+          label={`Color ${i}`}
+          color={underglowData[`color${i}`]}
+          setColor={(hue, sat) => this.props.updateColor(i, hue, sat)}
+        />
+      ));
+    }
+    return res;
+  }
+
+  renderSelectedCategory(category) {
+    const {underglowData} = this.props;
+    const {api} = this.props;
+
+    console.log('underglowData', underglowData);
+
+    if (api && underglowData) {
+      const {brightness, rgbMode} = underglowData;
+      // TODO: move this info to pattern.js
+      const colorsNeededArr = [0, 1, 4, 3, 6, 6, 3, 0, 6, 0, 0];
+      const colorsNeeded = colorsNeededArr[rgbMode];
+      switch (category) {
+        case Category.Pattern:
+          return (
+            <div>
+              <PatternCategory
+                rgbMode={rgbMode}
+                setRGBMode={mode => this.props.updateRGBMode(mode)}
+              />
+              <div className={styles.colorControls}>
+                {this.renderColors(colorsNeeded)};
+              </div>
+            </div>
+          );
+      }
+    }
+    return null;
+  }
+
+  render() {
+    return (
+      <div className={styles.menu}>
+        {this.renderCategories()}
+        {this.renderSelectedCategory(this.state.selectedCategory)}
+      </div>
+    );
+  }
+}

--- a/app/components/title-bar.js
+++ b/app/components/title-bar.js
@@ -8,6 +8,7 @@ import {
 export const Title = {
   KEYS: 'Keys',
   LIGHTING: 'Lighting',
+  UNDERGLOW: 'Underglow',
   DEBUG: 'Debug'
 };
 
@@ -30,6 +31,9 @@ export class TitleBar extends Component {
       )
     ) {
       titles = [...titles, Title.LIGHTING];
+    }
+    if (this.props.getKeyboard().underglow) {
+      titles = [...titles, Title.UNDERGLOW];
     }
     if (
       process.env.NODE_ENV === 'development' ||

--- a/app/components/underglow-categories/index.js
+++ b/app/components/underglow-categories/index.js
@@ -1,0 +1,3 @@
+export {BrightnessCategory} from '../lighting-categories/brightness';
+export {ColorCategory} from '../lighting-categories/color';
+export {PatternCategory} from './pattern';

--- a/app/components/underglow-categories/pattern.js
+++ b/app/components/underglow-categories/pattern.js
@@ -1,0 +1,59 @@
+import React, {Component} from 'react';
+import styles from '../lighting-categories/pattern.css';
+
+// TODO: this is where we want this info, near the effect names
+// Ideally, in the same data struture!
+// const ColorsNeeded = [0, 1, 2, 2, 2, 0, 0, 0, 0, 0, 1];
+
+// |Mode number symbol           |Additional number  |Description                            |
+// |-----------------------------|-------------------|---------------------------------------|
+// |`RGBLIGHT_MODE_STATIC_LIGHT` | *None*            |Solid color (this mode is always enabled) |
+// |`RGBLIGHT_MODE_BREATHING`    | 0,1,2,3           |Solid color breathing                  |
+// |`RGBLIGHT_MODE_RAINBOW_MOOD` | 0,1,2             |Cycling rainbow                        |
+// |`RGBLIGHT_MODE_RAINBOW_SWIRL`| 0,1,2,3,4,5       |Swirling rainbow                       |
+// |`RGBLIGHT_MODE_SNAKE`        | 0,1,2,3,4,5       |Snake                                  |
+// |`RGBLIGHT_MODE_KNIGHT`       | 0,1,2             |Knight                                 |
+// |`RGBLIGHT_MODE_CHRISTMAS`    | *None*            |Christmas                              |
+// |`RGBLIGHT_MODE_STATIC_GRADIENT`| 0,1,..,9        |Static gradient                        |
+// |`RGBLIGHT_MODE_RGB_TEST`     | *None*            |RGB Test                               |
+// |`RGBLIGHT_MODE_ALTERNATING`  | *None*            |Alternating                            |
+
+const Pattern = [
+  'All Off',
+  'Solid Color',
+  'Breathing',
+  'Cycling Rainbow',
+  'Swirling Rainbow',
+  'Snake',
+  'Knight',
+  'Christmas',
+  'Gradient',
+  'RGB Test',
+  'Alternating',
+];
+
+export class PatternCategory extends Component {
+  updatePattern(patternNum) {
+    this.props.setRGBMode(patternNum);
+  }
+
+  render() {
+    const {rgbMode} = this.props;
+    return (
+      <div className={styles.patternContainer}>
+        {Pattern.map((p, idx) => (
+          <div
+            className={[
+              rgbMode === idx && styles.selected,
+              styles.pattern
+            ].join(' ')}
+            onClick={() => this.updatePattern(idx)}
+            key={idx}
+          >
+            {p}
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/utils/device-meta.js
+++ b/app/utils/device-meta.js
@@ -22,7 +22,8 @@ import {
   LAYOUT_PLAIN60,
   LAYOUT_268_2,
   LAYOUT_IRIS,
-  LAYOUT_SNAGPAD
+  LAYOUT_SNAGPAD,
+  LAYOUT_DZ60,
 } from './kle-parser';
 
 export type Device = {
@@ -145,7 +146,13 @@ export const DEVICE_META_MAP: DeviceMetaMap = {
     name: 'Snagpad',
     layout: LAYOUT_SNAGPAD,
     lights: false
-  }
+  },
+  [0xFEED2260]: {
+    name: 'DZ60',
+    layout: LAYOUT_DZ60,
+    lights: false,
+    underglow: true,
+  },
 };
 
 const COMPILED_DEVICE_META_MAP = Object.entries(DEVICE_META_MAP).reduce(

--- a/app/utils/hid-keyboards.js
+++ b/app/utils/hid-keyboards.js
@@ -48,7 +48,8 @@ function isValidVendorProduct({productId, vendorId}: Device) {
     0x47050160, // Plain60
     0x4e580044, // 268.2
     0xcb101256, // Iris
-    0x44435350 // Snagpad
+    0x44435350, // Snagpad
+    0xFEED2260, // DZ60
   ];
   // JS bitwise operations is only 32-bit so we lose numbers if we shift too high
   const vendorProductId = vendorId * 65536 + productId;

--- a/app/utils/keyboard-api.js
+++ b/app/utils/keyboard-api.js
@@ -315,6 +315,10 @@ void *dynamic_keymap_key_to_eeprom_address(uint8_t layer, uint8_t row, uint8_t c
     await this.hidCommand(BACKLIGHT_CONFIG_SAVE);
   }
 
+  async saveUnderglow() {
+    await this.hidCommand(BACKLIGHT_CONFIG_SAVE);
+  }
+
   async resetEEPROM() {
     const bytes = [];
     await this.hidCommand(EEPROM_RESET);

--- a/app/utils/kle-parser.js
+++ b/app/utils/kle-parser.js
@@ -144,6 +144,12 @@ export const LAYOUT_SNAGPAD = `[{c:"#505557",t:"#d9d7d7",a:7},"x","x","x","x"],
 ["x","x","x","x"],
 ["x","x","x","x"]`;
 
+export const LAYOUT_DZ60 = `["Esc","!\n1","@\n2","#\n3","$\n4","%\n5","^\n6","&\n7","*\n8","(\n9",")\n0","_\n-","+\n=","|\n\\",{c:"#4d525a",t:"#e2e2e2"},"n"],
+[{w:1.5},"Tab","Q","W","E","R","T","Y","U","I","O","P","{\n[","}\n]",{w:1.5},"Backspace"],
+[{w:1.75},"Caps Lock","A","S","D","F","G","H","J","K","L",":\n;","'",{w:2.25},"Enter"],
+[{w:2.25},"Shift","Z","X","C","V","B","N","M","<\n,",">\n.","?\n/",{w:1.75},"Shift","Fn"],
+[{w:1.5},"Ctrl","Win",{w:1.5},"Alt",{a:7,w:7},"",{a:4,w:1.5},"Alt","Win",{w:1.5},"Ctrl"]`;
+
 export function parseKLERaw(kle: string): ParsedKLE {
   const kleArr = kle.split(',\n');
   const parsedKLE: OuterReduceState = kleArr.reduce(

--- a/app/utils/layout-parser.js
+++ b/app/utils/layout-parser.js
@@ -303,6 +303,22 @@ export const MATRIX_PLAIN60 = `
     {k40, k41, k42, XXX, XXX, XXX, k46, XXX, XXX, XXX, k4a, k4b, k4c, k4d, XXX}  \
 }`;
 
+export const MATRIX_DZ60 = `
+#define LAYOUT_60_tsangan_hhkb( \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
+    k10,      k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d, k1e, \
+    k20,      k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k2d,      \
+    k30,      k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b,      k3d, k3e, \
+    k40, k41,      k43,           k46,                     k4b,      k4d, k4e  \
+) { \
+    { k00,   k01,   k02,   k03,  k04,   k05,   k06,  k07,   k08,   k09,   k0a,   k0b,  k0c,   k0d,  k0e   }, \
+    { k10,   KC_NO, k12,   k13,  k14,   k15,   k16,  k17,   k18,   k19,   k1a,   k1b,  k1c,   k1d,  k1e   }, \
+    { k20,   KC_NO, k22,   k23,  k24,   k25,   k26,  k27,   k28,   k29,   k2a,   k2b,  k2c,   k2d,  KC_NO }, \
+    { k30,   KC_NO, k32,   k33,  k34,   k35,   k36,  k37,   k38,   k39,   k3a,   k3b,  KC_NO, k3d,  k3e   }, \
+    { k40,   k41,   KC_NO, k43,  KC_NO, KC_NO, k46,  KC_NO, KC_NO, KC_NO, KC_NO, k4b,  KC_NO, k4d,  k4e   }  \
+}
+`;
+
 const LS = {
   START: 1,
   DEFINE: 2,
@@ -337,7 +353,8 @@ export const MatrixLayout = {
   IRIS: parseLayout(MATRIX_IRIS),
   PLAIN60: parseLayout(MATRIX_PLAIN60),
   'Noxary 268.2': parseLayout(MATRIX_268_2),
-  'Snagpad': parseLayout(MATRIX_SNAGPAD)
+  'Snagpad': parseLayout(MATRIX_SNAGPAD),
+  'DZ60': parseLayout(MATRIX_DZ60),
 };
 
 function error(state, nextToken) {


### PR DESCRIPTION
This pull request adds a new menu item to VIA and communicates with a new QMK API that handles QMK standard underglow. The initial board I used for testing was the DZ60. I used this board because I understand it's one of the most used boards by the community and very widespread.

This PR also depends on the following QMK PR, that implements the QMK API counterpart:
https://github.com/qmk/qmk_firmware/pull/4915

Here's an overview of the new interface:
![via-qmk-underglow](https://user-images.githubusercontent.com/1371/51575109-e1e09e80-1e97-11e9-8f5c-088d43b27cf9.gif)

I have thoroughly tested my implementation and also performed a good sum of regression testing by unplugging the DZ60 and plugging an M60-A and it worked flawlessly.
